### PR TITLE
APO-002: Add orchestrator state machine and CI

### DIFF
--- a/.github/workflows/apo-002-ci.yml
+++ b/.github/workflows/apo-002-ci.yml
@@ -1,0 +1,42 @@
+name: APO-002 CI
+
+on:
+  push:
+    branches:
+      - agent/apo-002-ci
+    paths:
+      - 'engineering/APO-002/**'
+      - '.github/workflows/apo-002-ci.yml'
+  pull_request:
+    paths:
+      - 'engineering/APO-002/**'
+      - '.github/workflows/apo-002-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engineering/APO-002
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore APO-002.sln
+
+      - name: Build
+        run: dotnet build APO-002.sln --configuration Release --no-restore
+
+      - name: Run focused tests
+        run: dotnet run --project tests/APO-002.Tests/APO-002.Tests.csproj --configuration Release --no-build

--- a/engineering/APO-002/APO-002.sln
+++ b/engineering/APO-002/APO-002.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "APO-002", "src/APO-002/APO-002.csproj", "{7A1A4F5A-2A0C-45B4-91A3-6EF9529FD3D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "APO-002.Tests", "tests/APO-002.Tests/APO-002.Tests.csproj", "{F13F558E-3E3C-4CD5-A72B-2A2C79B73CC8}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {7A1A4F5A-2A0C-45B4-91A3-6EF9529FD3D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7A1A4F5A-2A0C-45B4-91A3-6EF9529FD3D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7A1A4F5A-2A0C-45B4-91A3-6EF9529FD3D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7A1A4F5A-2A0C-45B4-91A3-6EF9529FD3D1}.Release|Any CPU.Build.0 = Release|Any CPU
+        {F13F558E-3E3C-4CD5-A72B-2A2C79B73CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {F13F558E-3E3C-4CD5-A72B-2A2C79B73CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {F13F558E-3E3C-4CD5-A72B-2A2C79B73CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {F13F558E-3E3C-4CD5-A72B-2A2C79B73CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/engineering/APO-002/src/APO-002/APO-002.csproj
+++ b/engineering/APO-002/src/APO-002/APO-002.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/engineering/APO-002/src/APO-002/OrchestrationStateMachine.cs
+++ b/engineering/APO-002/src/APO-002/OrchestrationStateMachine.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+
+namespace WalkInTheWord.AIPublishing.Orchestration;
+
+public enum OrchestrationState
+{
+    Created = 0,
+    Validating = 1,
+    Ready = 2,
+    Running = 3,
+    Succeeded = 4,
+    Failed = 5,
+    Cancelled = 6,
+    Rejected = 7
+}
+
+public sealed record OrchestrationTransition(
+    OrchestrationState From,
+    OrchestrationState To);
+
+public static class OrchestrationStateMachine
+{
+    private static readonly ImmutableDictionary<OrchestrationState, ImmutableArray<OrchestrationState>>
+        AllowedTransitions = new Dictionary<OrchestrationState, ImmutableArray<OrchestrationState>>
+        {
+            [OrchestrationState.Created] =
+                [OrchestrationState.Validating, OrchestrationState.Cancelled],
+            [OrchestrationState.Validating] =
+                [OrchestrationState.Ready, OrchestrationState.Rejected, OrchestrationState.Failed, OrchestrationState.Cancelled],
+            [OrchestrationState.Ready] =
+                [OrchestrationState.Running, OrchestrationState.Cancelled],
+            [OrchestrationState.Running] =
+                [OrchestrationState.Succeeded, OrchestrationState.Failed, OrchestrationState.Cancelled],
+            [OrchestrationState.Succeeded] = [],
+            [OrchestrationState.Failed] = [],
+            [OrchestrationState.Cancelled] = [],
+            [OrchestrationState.Rejected] = []
+        }.ToImmutableDictionary();
+
+    public static bool IsTerminal(OrchestrationState state) =>
+        GetAllowedTransitions(state).IsEmpty;
+
+    public static bool CanTransition(
+        OrchestrationState from,
+        OrchestrationState to) =>
+        GetAllowedTransitions(from).Contains(to);
+
+    public static OrchestrationTransition CreateTransition(
+        OrchestrationState from,
+        OrchestrationState to)
+    {
+        if (!CanTransition(from, to))
+        {
+            throw new InvalidOperationException(
+                $"Transition from '{from}' to '{to}' is not permitted.");
+        }
+
+        return new OrchestrationTransition(from, to);
+    }
+
+    public static ImmutableArray<OrchestrationState> GetAllowedTransitions(
+        OrchestrationState state) =>
+        AllowedTransitions.TryGetValue(state, out var transitions)
+            ? transitions
+            : throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown orchestration state.");
+}

--- a/engineering/APO-002/tests/APO-002.Tests/APO-002.Tests.csproj
+++ b/engineering/APO-002/tests/APO-002.Tests/APO-002.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/APO-002/APO-002.csproj" />
+  </ItemGroup>
+</Project>

--- a/engineering/APO-002/tests/APO-002.Tests/Program.cs
+++ b/engineering/APO-002/tests/APO-002.Tests/Program.cs
@@ -1,0 +1,62 @@
+using WalkInTheWord.AIPublishing.Orchestration;
+
+Assert(OrchestrationStateMachine.CanTransition(
+    OrchestrationState.Created,
+    OrchestrationState.Validating));
+
+Assert(OrchestrationStateMachine.CanTransition(
+    OrchestrationState.Validating,
+    OrchestrationState.Ready));
+
+Assert(OrchestrationStateMachine.CanTransition(
+    OrchestrationState.Running,
+    OrchestrationState.Succeeded));
+
+Assert(!OrchestrationStateMachine.CanTransition(
+    OrchestrationState.Succeeded,
+    OrchestrationState.Running));
+
+Assert(OrchestrationStateMachine.IsTerminal(OrchestrationState.Succeeded));
+Assert(OrchestrationStateMachine.IsTerminal(OrchestrationState.Failed));
+Assert(OrchestrationStateMachine.IsTerminal(OrchestrationState.Cancelled));
+Assert(OrchestrationStateMachine.IsTerminal(OrchestrationState.Rejected));
+Assert(!OrchestrationStateMachine.IsTerminal(OrchestrationState.Running));
+
+var transition = OrchestrationStateMachine.CreateTransition(
+    OrchestrationState.Ready,
+    OrchestrationState.Running);
+
+Assert(transition == new OrchestrationTransition(
+    OrchestrationState.Ready,
+    OrchestrationState.Running));
+
+AssertThrows<InvalidOperationException>(() =>
+    OrchestrationStateMachine.CreateTransition(
+        OrchestrationState.Created,
+        OrchestrationState.Succeeded));
+
+Console.WriteLine("APO-002 tests passed.");
+
+static void Assert(bool condition)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException("Assertion failed.");
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(
+        $"Expected exception '{typeof(TException).Name}' was not thrown.");
+}


### PR DESCRIPTION
## Summary
- adds the APO-002 .NET 8 orchestration state machine
- adds focused executable tests
- adds a GitHub Actions workflow for restore, Release build, and test execution

## Evidence goal
This pull request moves APO-002 from static review to executable CI verification. The artifact should not be baselined until the workflow completes successfully.

## Scope
- `engineering/APO-002/**`
- `.github/workflows/apo-002-ci.yml`

No persistence, telemetry, workflow execution logic, or BP1 dependencies are introduced.