### PR TITLE
APO-003: Add deterministic workflow dispatcher

### DIFF
--- a/.github/workflows/apo-003-ci.yml
+++ b/.github/workflows/apo-003-ci.yml
@@ -1,0 +1,32 @@
+name: APO-003 CI
+
+on:
+  pull_request:
+    paths:
+      - 'engineering/APO-003/**'
+      - '.github/workflows/apo-003-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore engineering/APO-003/tests/APO-003.Tests/APO-003.Tests.csproj
+
+      - name: Build
+        run: dotnet build engineering/APO-003/tests/APO-003.Tests/APO-003.Tests.csproj --configuration Release --no-restore
+
+      - name: Run focused tests
+        run: dotnet run --project engineering/APO-003/tests/APO-003.Tests/APO-003.Tests.csproj --configuration Release --no-build

--- a/engineering/APO-003/src/APO-003/WorkflowDispatcher.cs
+++ b/engineering/APO-003/src/APO-003/WorkflowDispatcher.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+
+namespace WalkInTheWord.AIPublishing.Orchestration.Dispatching;
+
+public enum DispatchOutcome
+{
+    Dispatched = 0,
+    StageNotFound = 1
+}
+
+public sealed record DispatchRequest(
+    string ExecutionId,
+    string StageId,
+    string CanonicalInput);
+
+public sealed record DispatchResult(
+    string ExecutionId,
+    string StageId,
+    DispatchOutcome Outcome,
+    string? CanonicalOutput,
+    string? DiagnosticCode);
+
+public interface IWorkflowDispatchStage
+{
+    string StageId { get; }
+
+    ValueTask<string> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class WorkflowDispatcher
+{
+    private readonly ImmutableDictionary<string, IWorkflowDispatchStage> _stages;
+
+    public WorkflowDispatcher(IEnumerable<IWorkflowDispatchStage> stages)
+    {
+        ArgumentNullException.ThrowIfNull(stages);
+
+        var builder = ImmutableDictionary.CreateBuilder<string, IWorkflowDispatchStage>(
+            StringComparer.Ordinal);
+
+        foreach (var stage in stages)
+        {
+            ArgumentNullException.ThrowIfNull(stage);
+
+            if (string.IsNullOrWhiteSpace(stage.StageId))
+            {
+                throw new ArgumentException("A workflow stage must have a non-empty stage identifier.", nameof(stages));
+            }
+
+            if (!builder.TryAdd(stage.StageId, stage))
+            {
+                throw new ArgumentException(
+                    $"Duplicate workflow stage identifier '{stage.StageId}'.",
+                    nameof(stages));
+            }
+        }
+
+        _stages = builder.ToImmutable();
+    }
+
+    public async ValueTask<DispatchResult> DispatchAsync(
+        DispatchRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ExecutionId))
+        {
+            throw new ArgumentException("ExecutionId is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StageId))
+        {
+            throw new ArgumentException("StageId is required.", nameof(request));
+        }
+
+        ArgumentNullException.ThrowIfNull(request.CanonicalInput);
+
+        if (!_stages.TryGetValue(request.StageId, out var stage))
+        {
+            return new DispatchResult(
+                request.ExecutionId,
+                request.StageId,
+                DispatchOutcome.StageNotFound,
+                CanonicalOutput: null,
+                DiagnosticCode: "APO_DISPATCH_STAGE_NOT_FOUND");
+        }
+
+        var output = await stage
+            .ExecuteAsync(request.CanonicalInput, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new DispatchResult(
+            request.ExecutionId,
+            request.StageId,
+            DispatchOutcome.Dispatched,
+            output,
+            DiagnosticCode: null);
+    }
+}

--- a/engineering/APO-003/tests/APO-003.Tests/APO-003.Tests.csproj
+++ b/engineering/APO-003/tests/APO-003.Tests/APO-003.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/APO-003/APO-003.csproj" />
+  </ItemGroup>
+</Project>

--- a/engineering/APO-003/tests/APO-003.Tests/Program.cs
+++ b/engineering/APO-003/tests/APO-003.Tests/Program.cs
@@ -1,0 +1,134 @@
+using WalkInTheWord.AIPublishing.Orchestration.Dispatching;
+
+var tests = new (string Name, Func<ValueTask> Execute)[]
+{
+    ("dispatches registered stage", DispatchesRegisteredStage),
+    ("rejects missing stage", RejectsMissingStage),
+    ("rejects duplicate registration", RejectsDuplicateRegistration),
+    ("is independent of registration order", IsIndependentOfRegistrationOrder),
+    ("validates request identifiers", ValidatesRequestIdentifiers)
+};
+
+var failures = new List<string>();
+
+foreach (var test in tests)
+{
+    try
+    {
+        await test.Execute();
+        Console.WriteLine($"PASS: {test.Name}");
+    }
+    catch (Exception exception)
+    {
+        failures.Add($"FAIL: {test.Name}: {exception.Message}");
+    }
+}
+
+foreach (var failure in failures)
+{
+    Console.Error.WriteLine(failure);
+}
+
+return failures.Count == 0 ? 0 : 1;
+
+static async ValueTask DispatchesRegisteredStage()
+{
+    var dispatcher = new WorkflowDispatcher([new EchoStage("editorial")]);
+    var result = await dispatcher.DispatchAsync(new DispatchRequest("exec-001", "editorial", "input"));
+
+    AssertEqual(DispatchOutcome.Dispatched, result.Outcome);
+    AssertEqual("editorial:input", result.CanonicalOutput);
+    AssertEqual<string?>(null, result.DiagnosticCode);
+}
+
+static async ValueTask RejectsMissingStage()
+{
+    var dispatcher = new WorkflowDispatcher([]);
+    var result = await dispatcher.DispatchAsync(new DispatchRequest("exec-002", "missing", "input"));
+
+    AssertEqual(DispatchOutcome.StageNotFound, result.Outcome);
+    AssertEqual<string?>(null, result.CanonicalOutput);
+    AssertEqual("APO_DISPATCH_STAGE_NOT_FOUND", result.DiagnosticCode);
+}
+
+static ValueTask RejectsDuplicateRegistration()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new WorkflowDispatcher([new EchoStage("qa"), new EchoStage("qa")]));
+
+    return ValueTask.CompletedTask;
+}
+
+static async ValueTask IsIndependentOfRegistrationOrder()
+{
+    var request = new DispatchRequest("exec-003", "publish", "payload");
+    var first = new WorkflowDispatcher([new EchoStage("publish"), new EchoStage("research")]);
+    var second = new WorkflowDispatcher([new EchoStage("research"), new EchoStage("publish")]);
+
+    var firstResult = await first.DispatchAsync(request);
+    var secondResult = await second.DispatchAsync(request);
+
+    AssertEqual(firstResult, secondResult);
+}
+
+static async ValueTask ValidatesRequestIdentifiers()
+{
+    var dispatcher = new WorkflowDispatcher([new EchoStage("qa")]);
+
+    await AssertThrowsAsync<ArgumentException>(() =>
+        dispatcher.DispatchAsync(new DispatchRequest("", "qa", "input")));
+
+    await AssertThrowsAsync<ArgumentException>(() =>
+        dispatcher.DispatchAsync(new DispatchRequest("exec-004", "", "input")));
+}
+
+static void AssertEqual<T>(T expected, T actual)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"Expected '{expected}', actual '{actual}'.");
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}
+
+static async ValueTask AssertThrowsAsync<TException>(Func<ValueTask<DispatchResult>> action)
+    where TException : Exception
+{
+    try
+    {
+        await action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}
+
+file sealed class EchoStage(string stageId) : IWorkflowDispatchStage
+{
+    public string StageId { get; } = stageId;
+
+    public ValueTask<string> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult($"{StageId}:{canonicalInput}");
+    }
+}


### PR DESCRIPTION
## Summary
- adds immutable dispatch request/result contracts
- adds deterministic workflow-stage lookup and execution
- rejects missing stages and duplicate registrations
- verifies registration-order independence with focused executable tests
- adds .NET 8 CI for restore, Release build, and focused tests

## Scope
- `engineering/APO-003/**`
- `.github/workflows/apo-003-ci.yml`

Excluded: persistence, dependency-injection frameworks, telemetry, retries, parallel execution, external integrations, and pipeline coordination.