### PR TITLE
APO-004: Add deterministic stage registration

### DIFF
--- a/.github/workflows/apo-004-ci.yml
+++ b/.github/workflows/apo-004-ci.yml
@@ -1,0 +1,32 @@
+name: APO-004 CI
+
+on:
+  pull_request:
+    paths:
+      - 'engineering/APO-004/**'
+      - '.github/workflows/apo-004-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore engineering/APO-004/tests/APO-004.Tests/APO-004.Tests.csproj
+
+      - name: Build
+        run: dotnet build engineering/APO-004/tests/APO-004.Tests/APO-004.Tests.csproj --configuration Release --no-restore
+
+      - name: Run focused tests
+        run: dotnet run --project engineering/APO-004/tests/APO-004.Tests/APO-004.Tests.csproj --configuration Release --no-build

--- a/engineering/APO-004/src/APO-004/APO-004.csproj
+++ b/engineering/APO-004/src/APO-004/APO-004.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/engineering/APO-004/src/APO-004/StageRegistration.cs
+++ b/engineering/APO-004/src/APO-004/StageRegistration.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+
+namespace WalkInTheWord.AIPublishing.Orchestration.Registration;
+
+public sealed record StageRegistrationDescriptor
+{
+    public StageRegistrationDescriptor(string stageId, string stageType)
+    {
+        if (string.IsNullOrWhiteSpace(stageId))
+        {
+            throw new ArgumentException("StageId is required.", nameof(stageId));
+        }
+
+        if (string.IsNullOrWhiteSpace(stageType))
+        {
+            throw new ArgumentException("StageType is required.", nameof(stageType));
+        }
+
+        StageId = stageId;
+        StageType = stageType;
+    }
+
+    public string StageId { get; }
+
+    public string StageType { get; }
+}
+
+public sealed class StageRegistrationCollection
+{
+    private readonly ImmutableArray<StageRegistrationDescriptor> _registrations;
+    private readonly ImmutableDictionary<string, StageRegistrationDescriptor> _byStageId;
+
+    public StageRegistrationCollection(IEnumerable<StageRegistrationDescriptor> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var byId = ImmutableDictionary.CreateBuilder<string, StageRegistrationDescriptor>(
+            StringComparer.Ordinal);
+
+        foreach (var registration in registrations)
+        {
+            ArgumentNullException.ThrowIfNull(registration);
+
+            if (!byId.TryAdd(registration.StageId, registration))
+            {
+                throw new ArgumentException(
+                    $"Duplicate stage identifier '{registration.StageId}'.",
+                    nameof(registrations));
+            }
+        }
+
+        _registrations = byId.Values
+            .OrderBy(static registration => registration.StageId, StringComparer.Ordinal)
+            .ToImmutableArray();
+
+        _byStageId = byId.ToImmutable();
+    }
+
+    public ImmutableArray<StageRegistrationDescriptor> Registrations => _registrations;
+
+    public int Count => _registrations.Length;
+
+    public bool TryGet(string stageId, out StageRegistrationDescriptor? registration)
+    {
+        if (string.IsNullOrWhiteSpace(stageId))
+        {
+            registration = null;
+            return false;
+        }
+
+        return _byStageId.TryGetValue(stageId, out registration);
+    }
+}

--- a/engineering/APO-004/tests/APO-004.Tests/APO-004.Tests.csproj
+++ b/engineering/APO-004/tests/APO-004.Tests/APO-004.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/APO-004/APO-004.csproj" />
+  </ItemGroup>
+</Project>

--- a/engineering/APO-004/tests/APO-004.Tests/Program.cs
+++ b/engineering/APO-004/tests/APO-004.Tests/Program.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using WalkInTheWord.AIPublishing.Orchestration.Registration;
+
+var tests = new (string Name, Action Execute)[]
+{
+    ("orders registrations canonically", OrdersRegistrationsCanonically),
+    ("is independent of input order", IsIndependentOfInputOrder),
+    ("rejects duplicate identifiers", RejectsDuplicateIdentifiers),
+    ("looks up registrations without execution", LooksUpRegistrations),
+    ("returns false for missing identifiers", ReturnsFalseForMissingIdentifiers),
+    ("validates descriptor values", ValidatesDescriptorValues),
+    ("exposes immutable registration array", ExposesImmutableRegistrationArray)
+};
+
+var failures = new List<string>();
+
+foreach (var test in tests)
+{
+    try
+    {
+        test.Execute();
+        Console.WriteLine($"PASS: {test.Name}");
+    }
+    catch (Exception exception)
+    {
+        failures.Add($"FAIL: {test.Name}: {exception.Message}");
+    }
+}
+
+foreach (var failure in failures)
+{
+    Console.Error.WriteLine(failure);
+}
+
+return failures.Count == 0 ? 0 : 1;
+
+static void OrdersRegistrationsCanonically()
+{
+    var registrations = new StageRegistrationCollection(
+    [
+        new("publish", "PublicationStage"),
+        new("editorial", "EditorialStage"),
+        new("qa", "QualityAssuranceStage")
+    ]);
+
+    AssertSequenceEqual(
+        ["editorial", "publish", "qa"],
+        registrations.Registrations.Select(static item => item.StageId));
+}
+
+static void IsIndependentOfInputOrder()
+{
+    var first = new StageRegistrationCollection(
+    [
+        new("publish", "PublicationStage"),
+        new("editorial", "EditorialStage")
+    ]);
+
+    var second = new StageRegistrationCollection(
+    [
+        new("editorial", "EditorialStage"),
+        new("publish", "PublicationStage")
+    ]);
+
+    AssertSequenceEqual(first.Registrations, second.Registrations);
+}
+
+static void RejectsDuplicateIdentifiers()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new StageRegistrationCollection(
+        [
+            new("qa", "FirstStage"),
+            new("qa", "SecondStage")
+        ]));
+}
+
+static void LooksUpRegistrations()
+{
+    var registrations = new StageRegistrationCollection(
+    [
+        new("qa", "QualityAssuranceStage")
+    ]);
+
+    if (!registrations.TryGet("qa", out var registration))
+    {
+        throw new InvalidOperationException("Expected registration to be found.");
+    }
+
+    AssertEqual("QualityAssuranceStage", registration!.StageType);
+}
+
+static void ReturnsFalseForMissingIdentifiers()
+{
+    var registrations = new StageRegistrationCollection([]);
+
+    AssertFalse(registrations.TryGet("missing", out var missing));
+    AssertEqual<StageRegistrationDescriptor?>(null, missing);
+    AssertFalse(registrations.TryGet("", out var empty));
+    AssertEqual<StageRegistrationDescriptor?>(null, empty);
+}
+
+static void ValidatesDescriptorValues()
+{
+    AssertThrows<ArgumentException>(() => _ = new StageRegistrationDescriptor("", "Stage"));
+    AssertThrows<ArgumentException>(() => _ = new StageRegistrationDescriptor("qa", ""));
+}
+
+static void ExposesImmutableRegistrationArray()
+{
+    var registrations = new StageRegistrationCollection(
+    [
+        new("qa", "QualityAssuranceStage")
+    ]);
+
+    ImmutableArray<StageRegistrationDescriptor> snapshot = registrations.Registrations;
+    AssertEqual(1, snapshot.Length);
+    AssertEqual("qa", snapshot[0].StageId);
+}
+
+static void AssertEqual<T>(T expected, T actual)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"Expected '{expected}', actual '{actual}'.");
+    }
+}
+
+static void AssertFalse(bool value)
+{
+    if (value)
+    {
+        throw new InvalidOperationException("Expected false.");
+    }
+}
+
+static void AssertSequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+{
+    if (!expected.SequenceEqual(actual))
+    {
+        throw new InvalidOperationException(
+            $"Expected '[{string.Join(", ", expected)}]', actual '[{string.Join(", ", actual)}]'.");
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}


### PR DESCRIPTION
## Summary
- adds immutable stage registration descriptors
- adds deterministic canonical registration ordering
- enforces unique ordinal stage identifiers
- adds lookup without stage execution
- adds focused executable tests
- adds .NET 8 CI for restore, Release build, and focused tests

## Scope
- `engineering/APO-004/**`
- `.github/workflows/apo-004-ci.yml`

Excluded: dispatcher changes, orchestration sequencing, persistence, telemetry, dependency-injection infrastructure, retries, parallel execution, and external integrations.