### PR TITLE
APO-005: Add immutable execution context

### DIFF
--- a/.github/workflows/apo-005-ci.yml
+++ b/.github/workflows/apo-005-ci.yml
@@ -1,0 +1,32 @@
+name: APO-005 CI
+
+on:
+  pull_request:
+    paths:
+      - 'engineering/APO-005/**'
+      - '.github/workflows/apo-005-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore engineering/APO-005/tests/APO-005.Tests/APO-005.Tests.csproj
+
+      - name: Build
+        run: dotnet build engineering/APO-005/tests/APO-005.Tests/APO-005.Tests.csproj --configuration Release --no-restore
+
+      - name: Run focused tests
+        run: dotnet run --project engineering/APO-005/tests/APO-005.Tests/APO-005.Tests.csproj --configuration Release --no-build

--- a/engineering/APO-005/src/APO-005/APO-005.csproj
+++ b/engineering/APO-005/src/APO-005/APO-005.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/engineering/APO-005/src/APO-005/ExecutionContext.cs
+++ b/engineering/APO-005/src/APO-005/ExecutionContext.cs
@@ -1,0 +1,157 @@
+using System.Collections.Immutable;
+
+namespace WalkInTheWord.AIPublishing.Orchestration.Execution;
+
+public enum OrchestrationExecutionState
+{
+    Created = 0,
+    Validating = 1,
+    Ready = 2,
+    Running = 3,
+    Succeeded = 4,
+    Failed = 5,
+    Cancelled = 6,
+    Rejected = 7
+}
+
+public sealed record OrchestrationExecutionContext
+{
+    public OrchestrationExecutionContext(
+        string executionId,
+        string correlationId,
+        OrchestrationExecutionState state,
+        IEnumerable<KeyValuePair<string, string>>? metadata = null,
+        bool isCancellationRequested = false)
+    {
+        if (string.IsNullOrWhiteSpace(executionId))
+        {
+            throw new ArgumentException("ExecutionId is required.", nameof(executionId));
+        }
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            throw new ArgumentException("CorrelationId is required.", nameof(correlationId));
+        }
+
+        if (!Enum.IsDefined(state))
+        {
+            throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown orchestration state.");
+        }
+
+        ExecutionId = executionId;
+        CorrelationId = correlationId;
+        State = state;
+        Metadata = CreateMetadata(metadata);
+        IsCancellationRequested = isCancellationRequested;
+    }
+
+    public string ExecutionId { get; }
+
+    public string CorrelationId { get; }
+
+    public OrchestrationExecutionState State { get; }
+
+    public ImmutableSortedDictionary<string, string> Metadata { get; }
+
+    public bool IsCancellationRequested { get; }
+
+    public OrchestrationExecutionContext WithState(OrchestrationExecutionState state)
+    {
+        if (!Enum.IsDefined(state))
+        {
+            throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown orchestration state.");
+        }
+
+        return state == State
+            ? this
+            : new OrchestrationExecutionContext(
+                ExecutionId,
+                CorrelationId,
+                state,
+                Metadata,
+                IsCancellationRequested);
+    }
+
+    public OrchestrationExecutionContext WithMetadata(string key, string value)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Metadata key is required.", nameof(key));
+        }
+
+        ArgumentNullException.ThrowIfNull(value);
+
+        var updated = Metadata.SetItem(key, value);
+
+        return ReferenceEquals(updated, Metadata)
+            ? this
+            : new OrchestrationExecutionContext(
+                ExecutionId,
+                CorrelationId,
+                State,
+                updated,
+                IsCancellationRequested);
+    }
+
+    public OrchestrationExecutionContext WithoutMetadata(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Metadata key is required.", nameof(key));
+        }
+
+        var updated = Metadata.Remove(key);
+
+        return ReferenceEquals(updated, Metadata)
+            ? this
+            : new OrchestrationExecutionContext(
+                ExecutionId,
+                CorrelationId,
+                State,
+                updated,
+                IsCancellationRequested);
+    }
+
+    public OrchestrationExecutionContext RequestCancellation()
+    {
+        return IsCancellationRequested
+            ? this
+            : new OrchestrationExecutionContext(
+                ExecutionId,
+                CorrelationId,
+                State,
+                Metadata,
+                isCancellationRequested: true);
+    }
+
+    private static ImmutableSortedDictionary<string, string> CreateMetadata(
+        IEnumerable<KeyValuePair<string, string>>? metadata)
+    {
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, string>(
+            StringComparer.Ordinal);
+
+        if (metadata is null)
+        {
+            return builder.ToImmutable();
+        }
+
+        foreach (var pair in metadata)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                throw new ArgumentException("Metadata keys must be non-empty.", nameof(metadata));
+            }
+
+            ArgumentNullException.ThrowIfNull(pair.Value);
+
+            if (!builder.TryAdd(pair.Key, pair.Value))
+            {
+                throw new ArgumentException(
+                    $"Duplicate metadata key '{pair.Key}'.",
+                    nameof(metadata));
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/engineering/APO-005/tests/APO-005.Tests/APO-005.Tests.csproj
+++ b/engineering/APO-005/tests/APO-005.Tests/APO-005.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/APO-005/APO-005.csproj" />
+  </ItemGroup>
+</Project>

--- a/engineering/APO-005/tests/APO-005.Tests/Program.cs
+++ b/engineering/APO-005/tests/APO-005.Tests/Program.cs
@@ -1,0 +1,232 @@
+using WalkInTheWord.AIPublishing.Orchestration.Execution;
+
+var tests = new (string Name, Action Execute)[]
+{
+    ("creates immutable context", CreatesImmutableContext),
+    ("orders metadata canonically", OrdersMetadataCanonically),
+    ("updates state by returning new context", UpdatesStateByReturningNewContext),
+    ("updates metadata by returning new context", UpdatesMetadataByReturningNewContext),
+    ("removes metadata by returning new context", RemovesMetadataByReturningNewContext),
+    ("requests cancellation by returning new context", RequestsCancellationByReturningNewContext),
+    ("preserves original instance after updates", PreservesOriginalInstanceAfterUpdates),
+    ("rejects duplicate metadata keys", RejectsDuplicateMetadataKeys),
+    ("validates identifiers and states", ValidatesIdentifiersAndStates)
+};
+
+var failures = new List<string>();
+
+foreach (var test in tests)
+{
+    try
+    {
+        test.Execute();
+        Console.WriteLine($"PASS: {test.Name}");
+    }
+    catch (Exception exception)
+    {
+        failures.Add($"FAIL: {test.Name}: {exception.Message}");
+    }
+}
+
+foreach (var failure in failures)
+{
+    Console.Error.WriteLine(failure);
+}
+
+return failures.Count == 0 ? 0 : 1;
+
+static void CreatesImmutableContext()
+{
+    var context = new OrchestrationExecutionContext(
+        "exec-001",
+        "corr-001",
+        OrchestrationExecutionState.Created);
+
+    AssertEqual("exec-001", context.ExecutionId);
+    AssertEqual("corr-001", context.CorrelationId);
+    AssertEqual(OrchestrationExecutionState.Created, context.State);
+    AssertEqual(0, context.Metadata.Count);
+    AssertFalse(context.IsCancellationRequested);
+}
+
+static void OrdersMetadataCanonically()
+{
+    var context = new OrchestrationExecutionContext(
+        "exec-002",
+        "corr-002",
+        OrchestrationExecutionState.Ready,
+        [
+            new("zeta", "3"),
+            new("alpha", "1"),
+            new("middle", "2")
+        ]);
+
+    AssertSequenceEqual(
+        ["alpha", "middle", "zeta"],
+        context.Metadata.Keys);
+}
+
+static void UpdatesStateByReturningNewContext()
+{
+    var original = new OrchestrationExecutionContext(
+        "exec-003",
+        "corr-003",
+        OrchestrationExecutionState.Created);
+
+    var updated = original.WithState(OrchestrationExecutionState.Validating);
+
+    AssertNotSame(original, updated);
+    AssertEqual(OrchestrationExecutionState.Created, original.State);
+    AssertEqual(OrchestrationExecutionState.Validating, updated.State);
+}
+
+static void UpdatesMetadataByReturningNewContext()
+{
+    var original = new OrchestrationExecutionContext(
+        "exec-004",
+        "corr-004",
+        OrchestrationExecutionState.Running);
+
+    var updated = original.WithMetadata("stage", "editorial");
+
+    AssertNotSame(original, updated);
+    AssertEqual(0, original.Metadata.Count);
+    AssertEqual("editorial", updated.Metadata["stage"]);
+}
+
+static void RemovesMetadataByReturningNewContext()
+{
+    var original = new OrchestrationExecutionContext(
+        "exec-005",
+        "corr-005",
+        OrchestrationExecutionState.Running,
+        [new("stage", "qa")]);
+
+    var updated = original.WithoutMetadata("stage");
+
+    AssertNotSame(original, updated);
+    AssertEqual(1, original.Metadata.Count);
+    AssertEqual(0, updated.Metadata.Count);
+}
+
+static void RequestsCancellationByReturningNewContext()
+{
+    var original = new OrchestrationExecutionContext(
+        "exec-006",
+        "corr-006",
+        OrchestrationExecutionState.Running);
+
+    var updated = original.RequestCancellation();
+
+    AssertNotSame(original, updated);
+    AssertFalse(original.IsCancellationRequested);
+    AssertTrue(updated.IsCancellationRequested);
+}
+
+static void PreservesOriginalInstanceAfterUpdates()
+{
+    var original = new OrchestrationExecutionContext(
+        "exec-007",
+        "corr-007",
+        OrchestrationExecutionState.Ready,
+        [new("a", "1")]);
+
+    _ = original
+        .WithState(OrchestrationExecutionState.Running)
+        .WithMetadata("b", "2")
+        .RequestCancellation();
+
+    AssertEqual(OrchestrationExecutionState.Ready, original.State);
+    AssertSequenceEqual(["a"], original.Metadata.Keys);
+    AssertFalse(original.IsCancellationRequested);
+}
+
+static void RejectsDuplicateMetadataKeys()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new OrchestrationExecutionContext(
+            "exec-008",
+            "corr-008",
+            OrchestrationExecutionState.Created,
+            [
+                new("duplicate", "one"),
+                new("duplicate", "two")
+            ]));
+}
+
+static void ValidatesIdentifiersAndStates()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new OrchestrationExecutionContext(
+            "",
+            "corr",
+            OrchestrationExecutionState.Created));
+
+    AssertThrows<ArgumentException>(() =>
+        _ = new OrchestrationExecutionContext(
+            "exec",
+            "",
+            OrchestrationExecutionState.Created));
+
+    AssertThrows<ArgumentOutOfRangeException>(() =>
+        _ = new OrchestrationExecutionContext(
+            "exec",
+            "corr",
+            (OrchestrationExecutionState)999));
+}
+
+static void AssertEqual<T>(T expected, T actual)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"Expected '{expected}', actual '{actual}'.");
+    }
+}
+
+static void AssertTrue(bool value)
+{
+    if (!value)
+    {
+        throw new InvalidOperationException("Expected true.");
+    }
+}
+
+static void AssertFalse(bool value)
+{
+    if (value)
+    {
+        throw new InvalidOperationException("Expected false.");
+    }
+}
+
+static void AssertNotSame(object first, object second)
+{
+    if (ReferenceEquals(first, second))
+    {
+        throw new InvalidOperationException("Expected different object references.");
+    }
+}
+
+static void AssertSequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+{
+    if (!expected.SequenceEqual(actual))
+    {
+        throw new InvalidOperationException(
+            $"Expected '[{string.Join(", ", expected)}]', actual '[{string.Join(", ", actual)}]'.");
+    }
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}


### PR DESCRIPTION
## Summary
- adds immutable orchestration execution context
- validates execution and correlation identifiers
- stores metadata in deterministic ordinal key order
- supports immutable state, metadata, and cancellation updates
- rejects duplicate or invalid metadata
- adds focused executable tests
- adds .NET 8 CI for restore, Release build, and focused tests

## Scope
- `engineering/APO-005/**`
- `.github/workflows/apo-005-ci.yml`

Excluded: persistence, telemetry exporters, logging providers, dependency injection, workflow execution, retries, scheduling, and external integrations.