### PR TITLE
APO-006: Add deterministic pipeline coordinator

### DIFF
--- a/.github/workflows/apo-006-ci.yml
+++ b/.github/workflows/apo-006-ci.yml
@@ -1,0 +1,32 @@
+name: APO-006 CI
+
+on:
+  pull_request:
+    paths:
+      - 'engineering/APO-006/**'
+      - '.github/workflows/apo-006-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore engineering/APO-006/tests/APO-006.Tests/APO-006.Tests.csproj
+
+      - name: Build
+        run: dotnet build engineering/APO-006/tests/APO-006.Tests/APO-006.Tests.csproj --configuration Release --no-restore
+
+      - name: Run focused tests
+        run: dotnet run --project engineering/APO-006/tests/APO-006.Tests/APO-006.Tests.csproj --configuration Release --no-build

--- a/engineering/APO-006/src/APO-006/APO-006.csproj
+++ b/engineering/APO-006/src/APO-006/APO-006.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/engineering/APO-006/src/APO-006/PipelineCoordinator.cs
+++ b/engineering/APO-006/src/APO-006/PipelineCoordinator.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+
+namespace WalkInTheWord.AIPublishing.Orchestration.Pipelines;
+
+public sealed record PipelineDefinition
+{
+    public PipelineDefinition(string pipelineId, IEnumerable<string> stageIds)
+    {
+        if (string.IsNullOrWhiteSpace(pipelineId))
+        {
+            throw new ArgumentException("PipelineId is required.", nameof(pipelineId));
+        }
+
+        ArgumentNullException.ThrowIfNull(stageIds);
+        var orderedStageIds = stageIds.ToImmutableArray();
+
+        if (orderedStageIds.IsDefaultOrEmpty)
+        {
+            throw new ArgumentException("A pipeline must contain at least one stage.", nameof(stageIds));
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var stageId in orderedStageIds)
+        {
+            if (string.IsNullOrWhiteSpace(stageId))
+            {
+                throw new ArgumentException("Pipeline stage identifiers must be non-empty.", nameof(stageIds));
+            }
+
+            if (!seen.Add(stageId))
+            {
+                throw new ArgumentException($"Duplicate pipeline stage identifier '{stageId}'.", nameof(stageIds));
+            }
+        }
+
+        PipelineId = pipelineId;
+        StageIds = orderedStageIds;
+    }
+
+    public string PipelineId { get; }
+
+    public ImmutableArray<string> StageIds { get; }
+}
+
+public enum PipelineStageOutcome
+{
+    Succeeded = 0,
+    Failed = 1
+}
+
+public sealed record PipelineStageResult(
+    string StageId,
+    PipelineStageOutcome Outcome,
+    string? CanonicalOutput,
+    string? DiagnosticCode);
+
+public interface IPipelineStage
+{
+    string StageId { get; }
+
+    ValueTask<PipelineStageResult> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default);
+}
+
+public enum PipelineOutcome
+{
+    Succeeded = 0,
+    Failed = 1
+}
+
+public sealed record PipelineResult(
+    string PipelineId,
+    PipelineOutcome Outcome,
+    string? CanonicalOutput,
+    ImmutableArray<string> CompletedStageIds,
+    string? FailedStageId,
+    string? DiagnosticCode);
+
+public sealed class PipelineCoordinator
+{
+    private readonly ImmutableDictionary<string, IPipelineStage> _stages;
+
+    public PipelineCoordinator(IEnumerable<IPipelineStage> stages)
+    {
+        ArgumentNullException.ThrowIfNull(stages);
+
+        var builder = ImmutableDictionary.CreateBuilder<string, IPipelineStage>(StringComparer.Ordinal);
+        foreach (var stage in stages)
+        {
+            ArgumentNullException.ThrowIfNull(stage);
+
+            if (string.IsNullOrWhiteSpace(stage.StageId))
+            {
+                throw new ArgumentException("Registered stages must have non-empty identifiers.", nameof(stages));
+            }
+
+            if (!builder.TryAdd(stage.StageId, stage))
+            {
+                throw new ArgumentException($"Duplicate registered stage identifier '{stage.StageId}'.", nameof(stages));
+            }
+        }
+
+        _stages = builder.ToImmutable();
+    }
+
+    public async ValueTask<PipelineResult> ExecuteAsync(
+        PipelineDefinition definition,
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(canonicalInput);
+
+        ValidateRegistrations(definition);
+
+        var completed = ImmutableArray.CreateBuilder<string>();
+        var currentInput = canonicalInput;
+
+        foreach (var stageId in definition.StageIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = await _stages[stageId]
+                .ExecuteAsync(currentInput, cancellationToken)
+                .ConfigureAwait(false);
+
+            ValidateStageResult(stageId, result);
+
+            if (result.Outcome == PipelineStageOutcome.Failed)
+            {
+                return new PipelineResult(
+                    definition.PipelineId,
+                    PipelineOutcome.Failed,
+                    CanonicalOutput: null,
+                    CompletedStageIds: completed.ToImmutable(),
+                    FailedStageId: stageId,
+                    DiagnosticCode: result.DiagnosticCode ?? "APO_PIPELINE_STAGE_FAILED");
+            }
+
+            completed.Add(stageId);
+            currentInput = result.CanonicalOutput!;
+        }
+
+        return new PipelineResult(
+            definition.PipelineId,
+            PipelineOutcome.Succeeded,
+            currentInput,
+            completed.ToImmutable(),
+            FailedStageId: null,
+            DiagnosticCode: null);
+    }
+
+    private void ValidateRegistrations(PipelineDefinition definition)
+    {
+        foreach (var stageId in definition.StageIds)
+        {
+            if (!_stages.ContainsKey(stageId))
+            {
+                throw new InvalidOperationException(
+                    $"Pipeline '{definition.PipelineId}' references unregistered stage '{stageId}'.");
+            }
+        }
+    }
+
+    private static void ValidateStageResult(string expectedStageId, PipelineStageResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (!string.Equals(expectedStageId, result.StageId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Stage '{expectedStageId}' returned result for '{result.StageId}'.");
+        }
+
+        if (!Enum.IsDefined(result.Outcome))
+        {
+            throw new InvalidOperationException($"Stage '{expectedStageId}' returned an unknown outcome.");
+        }
+
+        if (result.Outcome == PipelineStageOutcome.Succeeded && result.CanonicalOutput is null)
+        {
+            throw new InvalidOperationException(
+                $"Successful stage '{expectedStageId}' must return canonical output.");
+        }
+    }
+}

--- a/engineering/APO-006/tests/APO-006.Tests/APO-006.Tests.csproj
+++ b/engineering/APO-006/tests/APO-006.Tests/APO-006.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/APO-006/APO-006.csproj" />
+  </ItemGroup>
+</Project>

--- a/engineering/APO-006/tests/APO-006.Tests/Program.cs
+++ b/engineering/APO-006/tests/APO-006.Tests/Program.cs
@@ -1,0 +1,280 @@
+using WalkInTheWord.AIPublishing.Orchestration.Pipelines;
+
+var tests = new (string Name, Func<ValueTask> Execute)[]
+{
+    ("executes stages sequentially", ExecutesStagesSequentially),
+    ("preserves declared stage order", PreservesDeclaredStageOrder),
+    ("rejects unregistered stage", RejectsUnregisteredStage),
+    ("fails fast on stage failure", FailsFastOnStageFailure),
+    ("tracks completed stages", TracksCompletedStages),
+    ("rejects duplicate pipeline stage identifiers", RejectsDuplicatePipelineStageIdentifiers),
+    ("rejects duplicate registered stage identifiers", RejectsDuplicateRegisteredStageIdentifiers),
+    ("validates returned stage identity", ValidatesReturnedStageIdentity),
+    ("requires output from successful stage", RequiresOutputFromSuccessfulStage)
+};
+
+var failures = new List<string>();
+foreach (var test in tests)
+{
+    try
+    {
+        await test.Execute();
+        Console.WriteLine($"PASS: {test.Name}");
+    }
+    catch (Exception exception)
+    {
+        failures.Add($"FAIL: {test.Name}: {exception.Message}");
+    }
+}
+
+foreach (var failure in failures)
+{
+    Console.Error.WriteLine(failure);
+}
+
+return failures.Count == 0 ? 0 : 1;
+
+static async ValueTask ExecutesStagesSequentially()
+{
+    var coordinator = new PipelineCoordinator(
+    [
+        new TransformStage("first", input => $"first({input})"),
+        new TransformStage("second", input => $"second({input})")
+    ]);
+
+    var result = await coordinator.ExecuteAsync(
+        new PipelineDefinition("pipeline-001", ["first", "second"]),
+        "input");
+
+    AssertEqual(PipelineOutcome.Succeeded, result.Outcome);
+    AssertEqual("second(first(input))", result.CanonicalOutput);
+    AssertSequenceEqual(["first", "second"], result.CompletedStageIds);
+    AssertEqual<string?>(null, result.FailedStageId);
+}
+
+static async ValueTask PreservesDeclaredStageOrder()
+{
+    var executionLog = new List<string>();
+    var coordinator = new PipelineCoordinator(
+    [
+        new TransformStage("a", input => { executionLog.Add("a"); return input + "a"; }),
+        new TransformStage("b", input => { executionLog.Add("b"); return input + "b"; })
+    ]);
+
+    var result = await coordinator.ExecuteAsync(
+        new PipelineDefinition("pipeline-002", ["b", "a"]),
+        "");
+
+    AssertEqual("ba", result.CanonicalOutput);
+    AssertSequenceEqual(["b", "a"], executionLog);
+}
+
+static async ValueTask RejectsUnregisteredStage()
+{
+    var coordinator = new PipelineCoordinator([new TransformStage("registered", input => input)]);
+
+    await AssertThrowsAsync<InvalidOperationException>(() =>
+        coordinator.ExecuteAsync(
+            new PipelineDefinition("pipeline-003", ["missing"]),
+            "input"));
+}
+
+static async ValueTask FailsFastOnStageFailure()
+{
+    var trailingExecuted = false;
+    var coordinator = new PipelineCoordinator(
+    [
+        new TransformStage("first", input => $"first({input})"),
+        new FailingStage("failure", "APO_TEST_FAILURE"),
+        new TransformStage("trailing", input => { trailingExecuted = true; return input; })
+    ]);
+
+    var result = await coordinator.ExecuteAsync(
+        new PipelineDefinition("pipeline-004", ["first", "failure", "trailing"]),
+        "input");
+
+    AssertEqual(PipelineOutcome.Failed, result.Outcome);
+    AssertSequenceEqual(["first"], result.CompletedStageIds);
+    AssertEqual("failure", result.FailedStageId);
+    AssertEqual("APO_TEST_FAILURE", result.DiagnosticCode);
+    AssertFalse(trailingExecuted);
+}
+
+static async ValueTask TracksCompletedStages()
+{
+    var coordinator = new PipelineCoordinator(
+    [
+        new TransformStage("one", input => input + "1"),
+        new TransformStage("two", input => input + "2"),
+        new TransformStage("three", input => input + "3")
+    ]);
+
+    var result = await coordinator.ExecuteAsync(
+        new PipelineDefinition("pipeline-005", ["one", "two", "three"]),
+        "");
+
+    AssertSequenceEqual(["one", "two", "three"], result.CompletedStageIds);
+}
+
+static ValueTask RejectsDuplicatePipelineStageIdentifiers()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new PipelineDefinition("pipeline-006", ["duplicate", "duplicate"]));
+    return ValueTask.CompletedTask;
+}
+
+static ValueTask RejectsDuplicateRegisteredStageIdentifiers()
+{
+    AssertThrows<ArgumentException>(() =>
+        _ = new PipelineCoordinator(
+        [
+            new TransformStage("duplicate", input => input),
+            new TransformStage("duplicate", input => input)
+        ]));
+    return ValueTask.CompletedTask;
+}
+
+static async ValueTask ValidatesReturnedStageIdentity()
+{
+    var coordinator = new PipelineCoordinator([new MismatchedStage("expected", "different")]);
+
+    await AssertThrowsAsync<InvalidOperationException>(() =>
+        coordinator.ExecuteAsync(
+            new PipelineDefinition("pipeline-007", ["expected"]),
+            "input"));
+}
+
+static async ValueTask RequiresOutputFromSuccessfulStage()
+{
+    var coordinator = new PipelineCoordinator([new NullOutputStage("null-output")]);
+
+    await AssertThrowsAsync<InvalidOperationException>(() =>
+        coordinator.ExecuteAsync(
+            new PipelineDefinition("pipeline-008", ["null-output"]),
+            "input"));
+}
+
+static void AssertEqual<T>(T expected, T actual)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+    {
+        throw new InvalidOperationException($"Expected '{expected}', actual '{actual}'.");
+    }
+}
+
+static void AssertFalse(bool value)
+{
+    if (value)
+    {
+        throw new InvalidOperationException("Expected false.");
+    }
+}
+
+static void AssertSequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+{
+    if (!expected.SequenceEqual(actual))
+    {
+        throw new InvalidOperationException(
+            $"Expected '[{string.Join(", ", expected)}]', actual '[{string.Join(", ", actual)}]'.");
+    }
+}
+
+static async ValueTask AssertThrowsAsync<TException>(Func<ValueTask<PipelineResult>> action)
+    where TException : Exception
+{
+    try
+    {
+        await action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}
+
+static void AssertThrows<TException>(Action action)
+    where TException : Exception
+{
+    try
+    {
+        action();
+    }
+    catch (TException)
+    {
+        return;
+    }
+
+    throw new InvalidOperationException($"Expected {typeof(TException).Name}.");
+}
+
+file sealed class TransformStage(string stageId, Func<string, string> transform) : IPipelineStage
+{
+    public string StageId { get; } = stageId;
+
+    public ValueTask<PipelineStageResult> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(
+            new PipelineStageResult(
+                StageId,
+                PipelineStageOutcome.Succeeded,
+                transform(canonicalInput),
+                DiagnosticCode: null));
+    }
+}
+
+file sealed class FailingStage(string stageId, string diagnosticCode) : IPipelineStage
+{
+    public string StageId { get; } = stageId;
+
+    public ValueTask<PipelineStageResult> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(
+            new PipelineStageResult(
+                StageId,
+                PipelineStageOutcome.Failed,
+                CanonicalOutput: null,
+                diagnosticCode));
+    }
+}
+
+file sealed class MismatchedStage(string stageId, string returnedStageId) : IPipelineStage
+{
+    public string StageId { get; } = stageId;
+
+    public ValueTask<PipelineStageResult> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(
+            new PipelineStageResult(
+                returnedStageId,
+                PipelineStageOutcome.Succeeded,
+                canonicalInput,
+                DiagnosticCode: null));
+    }
+}
+
+file sealed class NullOutputStage(string stageId) : IPipelineStage
+{
+    public string StageId { get; } = stageId;
+
+    public ValueTask<PipelineStageResult> ExecuteAsync(
+        string canonicalInput,
+        CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(
+            new PipelineStageResult(
+                StageId,
+                PipelineStageOutcome.Succeeded,
+                CanonicalOutput: null,
+                DiagnosticCode: null));
+    }
+}


### PR DESCRIPTION
## Summary
- adds immutable pipeline definitions and results
- coordinates registered stages sequentially in declared order
- validates referenced stage registrations before execution
- fails fast when a stage fails
- tracks completed stages immutably
- validates returned stage identity and successful-stage output
- adds focused executable tests
- adds .NET 8 CI for restore, Release build, and focused tests

## Scope
- `engineering/APO-006/**`
- `.github/workflows/apo-006-ci.yml`

Excluded: persistence, retries, parallel execution, scheduling, telemetry exporters, external integrations, evidence packaging, and publication assembly.